### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An MCP server implementation providing access to college football statistics sou
 [![Python Version](https://img.shields.io/badge/python-3.11-green)](https://www.python.org/downloads/)
 [![CFBD API Version](https://img.shields.io/badge/CFBD_API-1.0-orange)](https://api.collegefootballdata.com/api/docs/?url=/api-docs.json)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![smithery badge](https://smithery.ai/badge/cfbd)](https://smithery.ai/servers/cfbd)
+[![smithery badge](https://smithery.ai/badge/cfbd)](https://smithery.ai/server/cfbd)
 
 
 ## Overview
@@ -58,7 +58,7 @@ However, Eastern Washington over Washington appears to be the largest upset of t
 
 ### Installing via Smithery
 
-To install College Football Data Server for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/cfbd):
+To install College Football Data Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/cfbd):
 
 ```bash
 npx -y @smithery/cli install cfbd --client claude

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An MCP server implementation providing access to college football statistics sou
 [![Python Version](https://img.shields.io/badge/python-3.11-green)](https://www.python.org/downloads/)
 [![CFBD API Version](https://img.shields.io/badge/CFBD_API-1.0-orange)](https://api.collegefootballdata.com/api/docs/?url=/api-docs.json)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![smithery badge](https://smithery.ai/badge/cfbd)](https://smithery.ai/servers/cfbd)
+
 
 ## Overview
 
@@ -53,6 +55,14 @@ However, Eastern Washington over Washington appears to be the largest upset of t
 - A College Football Data API key ([get one here](https://collegefootballdata.com/key))
 
 ## Installation
+
+### Installing via Smithery
+
+To install College Football Data Server for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/cfbd):
+
+```bash
+npx -y @smithery/cli install cfbd --client claude
+```
 
 1. Clone this repository:
 ```bash


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install College Football Data Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery.

Let me know if any tweaks have to be made!